### PR TITLE
Bump httpclient from 4.4.1 to 4.5.13 in /nanolets

### DIFF
--- a/nanolets/pom.xml
+++ b/nanolets/pom.xml
@@ -18,7 +18,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.4.1</version>
+			<version>4.5.13</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Bumps httpclient from 4.4.1 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:development ...