### PR TITLE
Bump httpclient from 4.4.1 to 4.5.13 in /fileupload

### DIFF
--- a/fileupload/pom.xml
+++ b/fileupload/pom.xml
@@ -30,7 +30,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.4.1</version>
+			<version>4.5.13</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Bumps httpclient from 4.4.1 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:development ...